### PR TITLE
Always build workers on 'make'

### DIFF
--- a/worker/Makefile
+++ b/worker/Makefile
@@ -1,9 +1,10 @@
+.PHONY: all worker child
 all: worker child
 
-worker: Dockerfile
+worker:
 	docker build -t si32-worker --build-arg API_ROUTE=$(API_ROUTE) .
 
-child: child/Dockerfile
+child:
 	cd child && docker build -t si32-child-bot .
 
 clean:


### PR DESCRIPTION
Every call to `make all|child|worker` will rebuild the target container now

This isn't really how make is supposed to be used, but whatever

Fixes #2 