### PR TITLE
Only store s3 key of bot code

### DIFF
--- a/api/app/models/botModel.js
+++ b/api/app/models/botModel.js
@@ -29,10 +29,7 @@ const _Bot = new Schema({
     timestamp: Date,
     _id: false
   }],
-  code: {
-    url: { type: String, },
-    key: { type: String, }
-  }
+  code: { type: String, },
 }, {
   timestamps: true
 });

--- a/api/app/models/matchModel.js
+++ b/api/app/models/matchModel.js
@@ -68,7 +68,7 @@ _Match.statics.getNext = () => {
         name: bot.name,
         id: bot._id,
         index: i,
-        url: s3.getBotUrl(bot.code.key),
+        url: s3.getBotUrl(bot.code),
       }
     ));
 

--- a/api/app/routes/botRoutes.js
+++ b/api/app/routes/botRoutes.js
@@ -34,7 +34,7 @@ botRouter.post("/", async (ctx) => {
   // TODO need some error handling/retrying here
   s3.uploadBot(ctx.state.userId, bot._id, ctx.request.body.files.code).then(({ url, key }) => {
     // update bot in db w/ code's url
-    bot.set("code", { url, key });
+    bot.set("code", key);
     bot.save();
   });
 
@@ -62,13 +62,13 @@ botRouter.post("/:botId", async (ctx) => {
     throw new AccessError("That's not your bot");
   }
 
-  const { url, key } = await s3.uploadBot(ctx.state.userId, bot._id, ctx.request.body.files.code);
+  const { key } = await s3.uploadBot(ctx.state.userId, bot._id, ctx.request.body.files.code);
 
   // delete this file to mark it as handled
   delete ctx.request.body.files.code;
 
   // update bot in db w/ code's url
-  bot.set("code", { url, key });
+  bot.set("code", key);
   bot.set("version", bot.version + 1);
   bot.save();
 


### PR DESCRIPTION
Saving the url is meaningless: any time we want to get a usable url we'll have to get a signed one since they're private; getting that private url only needs the key. 