### PR TITLE
Game fixes & prep for n-player

### DIFF
--- a/api/app/lib/trueskill.js
+++ b/api/app/lib/trueskill.js
@@ -12,13 +12,13 @@ const DEFAULT_SIGMA = 25.0 / 3;
   *   returns a map of player ids to their new mu and sigma
   * IMPT: This method does not mutate the player objects themselves, it only returns what their new score should be
 */
-module.exports.returnNewSkillOfPlayers = (playersInRankedOrder) => {
-  const playerSkills = playersInRankedOrder.map((playerObj, idx) => {
+module.exports.returnNewSkillOfPlayers = (players) => {
+  const playerSkills = players.map((playerObj) => {
     const skillScore = playerObj.skill || {mu: DEFAULT_MU, sigma: DEFAULT_SIGMA};
     return {
       _id: playerObj._id.toString(),
       skill: [skillScore.mu || DEFAULT_MU, skillScore.sigma || DEFAULT_SIGMA],
-      rank: idx,    // players index in playersInRankedOrder gives their relative rank in this game
+      rank: playerObj.rank,
     };
   });
 

--- a/api/app/models/matchModel.js
+++ b/api/app/models/matchModel.js
@@ -31,7 +31,7 @@ const _Match = new Schema({
 });
 
 _Match.statics.createWithBots = (userId, botIds) => {
-  assert(botIds.length == 2 && _.every(botIds, _.isString), "Need two bots to start a match!");
+  assert(2 <= botIds.length && botIds.length <= 4 && _.every(botIds, _.isString), "Need 2-4 bots to start a match!");
   return Bot.find({
     "_id": { $in: botIds }
   }).select({ code: 1, _id: 1, name: 1, user: 1, version: 1 }).lean().then(bots => {
@@ -97,11 +97,10 @@ _Match.statics.handleWorkerResponse = async (id, rankedBots, logKey, result={}) 
   // turn array of bots into obj keyed on bot ID storing ranked finish
   const botRankById = {};
   _.each(rankedBots, (b, i) => {
-    botRankById[b._id] = {
-      ...b,
-      rank: i + 1,
-    };
+    botRankById[b._id] = b;
   });
+
+  console.log("bots", rankedBots);
 
   // store the individual bots' skills and rank in this match
   const newBots = _.map(match.bots, b => {

--- a/api/app/models/matchModel.js
+++ b/api/app/models/matchModel.js
@@ -96,11 +96,9 @@ _Match.statics.handleWorkerResponse = async (id, rankedBots, logKey, result={}) 
 
   // turn array of bots into obj keyed on bot ID storing ranked finish
   const botRankById = {};
-  _.each(rankedBots, (b, i) => {
+  _.each(rankedBots, b  => {
     botRankById[b._id] = b;
   });
-
-  console.log("bots", rankedBots);
 
   // store the individual bots' skills and rank in this match
   const newBots = _.map(match.bots, b => {

--- a/game/Logger.py
+++ b/game/Logger.py
@@ -111,12 +111,14 @@ class Logger:
 
         self.turn_log['cmd'].append(clean_command)
 
-    def add_ranked_player(self, player):
-        self.log['rankedBots'].append({
-            '_id': player.bot.name,
-            'crashed': player.crashed,
-            'timedOut': player.timed_out,
-        })
+    def add_ranked_players(self, players):
+        for p in players: 
+            self.log['rankedBots'].append({
+                '_id': p.bot.name,
+                'crashed': p.crashed,
+                'timedOut': p.timed_out,
+                'rank': p.rank
+            })
 
     def get_log(self):
         return gzip.compress(msgpack.packb(self.log))

--- a/game/Player.py
+++ b/game/Player.py
@@ -25,6 +25,8 @@ class Player:
     def __init__(self, playerId, map, bot, starting_pos):
         self.bot = bot
 
+        self.rank = None # finih position
+
         self.winner = False
         self.timed_out = False
         self.crashed = False

--- a/web/src/components/matches/singlePage.jsx
+++ b/web/src/components/matches/singlePage.jsx
@@ -23,6 +23,7 @@ class MatchSinglePage extends React.PureComponent {
         return {};
       }
     }).then(log => {
+      console.log("log", log);
       this.setState({ log });
     });
   }
@@ -54,17 +55,20 @@ class MatchSinglePage extends React.PureComponent {
   }
 
   renderFailed = () => {
-    if (this.props.match.result.reason == "BOT_CRASHED") {
-      return (<div style={styles.failureMessage}>{"a bot crashed, we don't have a replay for this game :("}</div>);
-    }
+    return (<div style={styles.failureMessage}>{"we don't have a replay for this game :("}</div>);
   }
 
   renderReplay = () => {
+    console.log(this.props.match);
     if (this.props.match.result.success == false) {
       return this.renderFailed();
     }
 
     if (this.state.log) {
+      if (this.state.log.turns.length === 0) {
+        return this.renderFailed();
+      }
+
       return <ReplayVisualizer hideSelectButton replay={this.state.log} />;
     }
 

--- a/web/src/components/matches/singlePage.jsx
+++ b/web/src/components/matches/singlePage.jsx
@@ -23,7 +23,6 @@ class MatchSinglePage extends React.PureComponent {
         return {};
       }
     }).then(log => {
-      console.log("log", log);
       this.setState({ log });
     });
   }
@@ -59,7 +58,6 @@ class MatchSinglePage extends React.PureComponent {
   }
 
   renderReplay = () => {
-    console.log(this.props.match);
     if (this.props.match.result.success == false) {
       return this.renderFailed();
     }

--- a/worker/endpoints.py
+++ b/worker/endpoints.py
@@ -15,20 +15,6 @@ def get_bot_file(url, bnum):
     urllib.request.urlretrieve(url, '/bot' + str(bnum) + '/bot.py')
 
 # on success, just send the messagepack+gzipped game log
-def post_match_success(matchId, log):
+def post_match_results(matchId, log):
     files = {'log': ('log.mp.gz', log)}
     return requests.post(API + '/result/' + matchId, files=files)
-
-
-# on failure, send reasoning why
-def post_match_crash(matchId, rankedBots, crashedBot):
-    body = {
-        'matchId': matchId,
-        'result': {
-            'success': False,
-            'reason': 'BOT_CRASHED',
-        },
-        'rankedBots': rankedBots,
-    }
-
-    return requests.post(API + '/failed/' + matchId, json=body)


### PR DESCRIPTION
- fixes start position assignment from https://github.com/dartmouth-cs98/18w-si32/commit/84a1c02454b772ffccb4f39309059be3d32c1d88
- fixes non-terminating games from https://github.com/dartmouth-cs98/18w-si32/commit/68b57548a693b552c95c1776a2fe132fd3ca6ffa (resolves #260)
- handles ranking of bots more elegantly from worker side, and ranks in a way that should work for n-player
- handle games where bots crash through same code as successful games. This means we can now show game logs up until the point where a bot crashed, and reduces complexity w/in the worker.