### PR TITLE
Correctly populate user in newly created bot

### DIFF
--- a/api/app/routes/botRoutes.js
+++ b/api/app/routes/botRoutes.js
@@ -38,7 +38,7 @@ botRouter.post("/", async (ctx) => {
   bot.trueSkillHistory.push({ timestamp: new Date(), score: { mu: DEFAULT_MU, sigma: DEFAULT_SIGMA } });
   bot.save();
 
-  await bot.populate("user");
+  await bot.populate("user").execPopulate();
 
   // delete this file to mark it as handled
   delete ctx.request.body.files.code;


### PR DESCRIPTION
fixes issue where bot may appear under "other user's bots" in match page when redirected